### PR TITLE
Add multi-version support without git branches

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aztec",
-  "version": "1.0.0",
-  "description": "Claude Code plugin for Aztec smart contract and application development. Provides specialized agents, skills, and commands for building privacy-preserving applications on Aztec Network.",
+  "version": "2.0.0",
+  "description": "Claude Code plugin for Aztec smart contract and application development. Supports multiple Aztec versions (devnet, testnet, mainnet) with auto-detection from Nargo.toml.",
   "author": {
     "name": "critesjosh"
   },
@@ -12,10 +12,15 @@
     "privacy",
     "zk-rollup",
     "blockchain",
-    "web3"
+    "web3",
+    "multi-version"
   ],
   "license": "MIT",
   "repository": "https://github.com/critesjosh/aztec-claude-plugin",
+  "config": {
+    "defaultVersion": "devnet",
+    "supportedVersions": ["devnet", "testnet", "mainnet"]
+  },
   "mcpServers": {
     "context7": {
       "command": "npx",

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Local configuration
-network.json
+.aztec-version
 
 # Claude Code local settings
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,42 @@
 
 This project uses the Aztec Network for privacy-preserving smart contract development. Follow these guidelines when working with Aztec contracts and applications.
 
+## Version Detection
+
+This plugin supports multiple Aztec versions. **Default: devnet** (latest development).
+
+### Detecting Project Version
+
+When working with a user's Aztec project, detect their version:
+
+1. **Check for `.aztec-version`** file in project root (manual override)
+2. **Parse `Nargo.toml`** for the `aztec` dependency tag:
+   ```toml
+   aztec = { git = "...", tag = "aztec-packages-v0.87.4-devnet.0", ... }
+   ```
+3. **Match against version patterns** in `versions/versions.json`
+4. **Default to devnet** if no version detected
+
+### Supported Versions
+
+| Version | Tag Pattern | Status |
+|---------|-------------|--------|
+| devnet | `aztec-packages-v*-devnet*` or `v0.87+` | Default, active development |
+| testnet | `aztec-packages-v0.8[0-6]*` | Pre-release testing |
+| mainnet | `aztec-packages-v1.*` | Future stable release |
+
+### Version-Specific Syntax
+
+See `versions/<version>/syntax.md` for version-specific syntax reference. Key differences:
+- **Function attributes**: May vary between versions
+- **Storage patterns**: `Owned<>` wrapper requirements
+- **Note delivery**: `MessageDelivery` options
+
+When generating code, include a comment noting the target version:
+```rust
+// Target: Aztec devnet (aztec-packages-v0.87.x)
+```
+
 ## Technology Stack
 
 - **Noir**: Domain-specific language for writing Aztec smart contracts
@@ -265,9 +301,13 @@ name = "my_contract"
 type = "contract"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.XX.X", directory = "noir-projects/aztec-nr/aztec" }
-value_note = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.XX.X", directory = "noir-projects/aztec-nr/value-note" }
+# Use the same tag for all aztec-packages dependencies
+# Check https://github.com/AztecProtocol/aztec-packages/tags for latest
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.87.4-devnet.0", directory = "noir-projects/aztec-nr/aztec" }
+value_note = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.87.4-devnet.0", directory = "noir-projects/aztec-nr/value-note" }
 ```
+
+**Important**: Match the tag to your target network version. See `versions/versions.json` for version patterns.
 
 ## Looking Up Latest Documentation
 

--- a/NETWORK.md
+++ b/NETWORK.md
@@ -1,66 +1,91 @@
-# Network Versions
+# Version Support
 
-This plugin supports multiple Aztec network versions. Each network may have different syntax, APIs, and patterns.
+This plugin supports multiple Aztec versions within a single installation. No git branches or switching required.
 
-## Available Networks
+## Available Versions
 
-### mainnet
-- **Status**: Stable production release
-- **Aztec Version**: Latest stable
-- **Use when**: Deploying to production, building for mainnet users
+### devnet (Default)
+- **Status**: Active development
+- **Tag Pattern**: `aztec-packages-v*-devnet*` or `v0.87+`
+- **Use when**: New development, experimenting with latest features
+- **Syntax reference**: `versions/devnet/syntax.md`
 
 ### testnet
 - **Status**: Pre-release testing
-- **Aztec Version**: Release candidate
-- **Use when**: Testing before mainnet deployment, integration testing
+- **Tag Pattern**: `aztec-packages-v0.8[0-6]*`
+- **Use when**: Integration testing, pre-production validation
+- **Syntax reference**: `versions/testnet/syntax.md`
 
-### devnet
-- **Status**: Active development
-- **Aztec Version**: Latest development build
-- **Use when**: Experimenting with new features, contributing to Aztec
+### mainnet
+- **Status**: Future stable release
+- **Tag Pattern**: `aztec-packages-v1.*`
+- **Use when**: Production deployments (when available)
+- **Syntax reference**: `versions/mainnet/syntax.md`
 
-## Switching Networks
+## Version Detection
 
-```bash
-# Switch to testnet
-./setup.sh testnet
+The plugin auto-detects your project's version from `Nargo.toml`:
 
-# Switch to devnet
-./setup.sh devnet
-
-# Check current network
-./setup.sh status
+```toml
+[dependencies]
+aztec = { git = "...", tag = "aztec-packages-v0.87.4-devnet.0", directory = "..." }
 ```
 
-## Version Differences
+### Manual Selection
 
-### Syntax Changes by Version
+```bash
+./setup.sh devnet    # Use devnet syntax
+./setup.sh testnet   # Use testnet syntax
+./setup.sh mainnet   # Use mainnet syntax
+./setup.sh status    # Show current version
+./setup.sh detect    # Auto-detect from project
+```
 
-Each branch contains version-specific documentation in `CLAUDE.md` and the skills/commands directories. Key areas that may differ:
+### Using /aztec:detect-version
 
-| Feature | mainnet | testnet | devnet |
-|---------|---------|---------|--------|
-| Note delivery | `.deliver()` | `.deliver()` | `.deliver(MessageDelivery.*)` |
-| Storage patterns | `Map<>` | `Map<>` | `Owned<>` |
-| Function attributes | `#[aztec(private)]` | `#[external("private")]` | `#[external("private")]` |
+Run the slash command to scan your project and report the detected version with syntax details.
 
-> **Note**: This table is illustrative. Check the branch-specific `CLAUDE.md` for accurate syntax.
+## Syntax Differences by Version
 
-## Branch Management
+| Feature | devnet | testnet | mainnet |
+|---------|--------|---------|---------|
+| Function attributes | `#[external("private")]` | `#[external("private")]` | TBD |
+| Storage wrapping | `Owned<PrivateSet<>>` | `Owned<PrivateSet<>>` | TBD |
+| Note delivery | `MessageDelivery::CONSTRAINED_ONCHAIN` | `MessageDelivery::CONSTRAINED_ONCHAIN` | TBD |
 
-When updating the plugin for a new Aztec release:
+> **Note**: Mainnet syntax will be documented when mainnet launches. See `versions/<version>/syntax.md` for complete syntax references.
 
-1. Create/update the appropriate branch
-2. Update `CLAUDE.md` with new syntax
-3. Update skills and commands as needed
-4. Test with the target network
-5. Tag the release (e.g., `testnet-v0.87.0`)
+## Version Files
 
-## Compatibility
+```
+versions/
+├── versions.json          # Version patterns and metadata
+├── devnet/
+│   └── syntax.md          # Complete devnet syntax reference
+├── testnet/
+│   └── syntax.md          # Complete testnet syntax reference
+└── mainnet/
+    └── syntax.md          # Mainnet syntax (placeholder)
+```
 
-The plugin attempts to use syntax compatible with:
-- **mainnet**: aztec-packages stable releases
-- **testnet**: aztec-packages release candidates
-- **devnet**: aztec-packages master branch
+## Configuration
+
+The active version is stored in `.aztec-version`:
+
+```json
+{
+  "version": "devnet",
+  "setAt": "2025-01-13T00:00:00Z",
+  "note": "Plugin configured for devnet syntax."
+}
+```
+
+This file is created by `./setup.sh` and can be committed to your project to share version settings with your team.
+
+## Compatibility Notes
+
+- **Default behavior**: Uses devnet syntax if no version detected
+- **Version mismatch**: Claude will warn if multiple Nargo.toml files have different versions
+- **Unknown versions**: Falls back to devnet with a warning
 
 Always verify against the [official Aztec documentation](https://docs.aztec.network) for your target version.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Claude Code plugin for Aztec smart contract and application development. This plugin provides specialized agents, skills, and commands to help you build privacy-preserving applications on the Aztec Network.
 
-⚠️ This plugin is currently set up to run on v3.0.0-devnet.20251212
+**Supports multiple Aztec versions** with auto-detection from your project's Nargo.toml.
 
 ## Installation
 
@@ -39,36 +39,48 @@ git pull
 
 Changes take effect on the next Claude Code session.
 
-## Network Versions
+## Version Support
 
-This plugin supports multiple Aztec network versions with potentially different syntax. Switch between them based on your target deployment:
+This plugin supports multiple Aztec versions. **Default: devnet** (latest development).
 
-```bash
-# Clone with a specific network version
-git clone https://github.com/critesjosh/aztec-claude-plugin
-cd aztec-plugin
-./setup.sh testnet  # or: mainnet, devnet
+### Auto-Detection
+
+The plugin automatically detects your project's Aztec version from `Nargo.toml`:
+
+```toml
+aztec = { git = "...", tag = "aztec-packages-v0.87.4-devnet.0", ... }
 ```
 
-### Available Networks
+### Available Versions
 
-| Network   | Description               | Use Case                        |
-| --------- | ------------------------- | ------------------------------- |
-| `mainnet` | Stable production release | Production deployments          |
-| `testnet` | Pre-release testing       | Integration testing             |
-| `devnet`  | Latest development        | Experimenting with new features |
+| Version   | Tag Pattern                    | Status                         |
+| --------- | ------------------------------ | ------------------------------ |
+| `devnet`  | `aztec-packages-v*-devnet*`    | Default, active development    |
+| `testnet` | `aztec-packages-v0.8[0-6]*`    | Pre-release testing            |
+| `mainnet` | `aztec-packages-v1.*`          | Future stable release          |
 
-### Switching Networks
+### Manual Version Selection
 
 ```bash
-# Switch to a different network
-./setup.sh devnet
+# Set version manually
+./setup.sh devnet     # Use devnet syntax (default)
+./setup.sh testnet    # Use testnet syntax
+./setup.sh mainnet    # Use mainnet syntax (when available)
 
-# Check current network
+# Auto-detect from Nargo.toml
+./setup.sh detect
+
+# Check current version
 ./setup.sh status
 ```
 
-See [NETWORK.md](./NETWORK.md) for detailed version differences.
+### Slash Command
+
+```
+/aztec:detect-version    # Scan project and report version
+```
+
+See [NETWORK.md](./NETWORK.md) for detailed version differences and syntax references.
 
 ## Features
 
@@ -191,8 +203,12 @@ aztec-plugin/
 ├── .claude-plugin/
 │   └── plugin.json          # Plugin manifest
 ├── .lsp.json                # Noir LSP configuration
-├── setup.sh                 # Network version switcher
-├── network.json             # Current network config (git-ignored)
+├── setup.sh                 # Version selector (no git required)
+├── versions/                # Version-specific syntax references
+│   ├── versions.json        # Version definitions and patterns
+│   ├── devnet/syntax.md     # Devnet syntax reference
+│   ├── testnet/syntax.md    # Testnet syntax reference
+│   └── mainnet/syntax.md    # Mainnet syntax reference
 ├── NETWORK.md               # Version differences documentation
 ├── agents/
 │   ├── contract-reviewer.md # Contract review agent

--- a/commands/detect-version.md
+++ b/commands/detect-version.md
@@ -1,0 +1,74 @@
+---
+description: Detect and display the Aztec version for the current project
+---
+
+# Detect Aztec Version
+
+Scan the current project to determine which Aztec version is being used and report the appropriate syntax variant.
+
+## Instructions
+
+1. **Search for Nargo.toml files** in the project:
+   - Check project root
+   - Check `contracts/` directory
+   - Check any subdirectories with `Nargo.toml`
+
+2. **Extract the version tag** from the `aztec` dependency:
+   ```toml
+   aztec = { git = "...", tag = "aztec-packages-vX.Y.Z", directory = "..." }
+   ```
+
+3. **Match against version patterns**:
+   - `aztec-packages-v*-devnet*` or `v0.87+` → **devnet**
+   - `aztec-packages-v0.8[0-6]*` → **testnet**
+   - `aztec-packages-v1.*` → **mainnet**
+
+4. **Report findings**:
+   - Detected version (devnet/testnet/mainnet)
+   - Tag found in Nargo.toml
+   - Syntax reference file path
+   - Any version mismatches between multiple Nargo.toml files
+
+## Output Format
+
+```
+Aztec Version Detection
+=======================
+
+Nargo.toml files found:
+- contracts/token/Nargo.toml
+  Tag: aztec-packages-v0.87.4-devnet.0
+
+Detected version: devnet
+Syntax reference: versions/devnet/syntax.md
+
+Key syntax for this version:
+- Function attributes: #[external("private")]
+- Storage: Owned<PrivateSet<T, Context>, Context>
+- Note delivery: .deliver(MessageDelivery::CONSTRAINED_ONCHAIN)
+```
+
+## Version Mismatch Warning
+
+If multiple Nargo.toml files have different version tags, warn the user:
+
+```
+WARNING: Version mismatch detected!
+- contracts/token/Nargo.toml: aztec-packages-v0.87.4-devnet.0
+- contracts/bridge/Nargo.toml: aztec-packages-v0.85.0
+
+Recommendation: Align all dependencies to the same version.
+```
+
+## No Version Found
+
+If no Nargo.toml or no aztec dependency:
+
+```
+No Aztec version detected.
+Using default: devnet
+
+To set a specific version:
+- Run ./setup.sh <version>
+- Or create .aztec-version file
+```

--- a/versions/devnet/syntax.md
+++ b/versions/devnet/syntax.md
@@ -1,0 +1,145 @@
+# Devnet Syntax Reference
+
+This document contains the canonical syntax for Aztec devnet (latest development version).
+
+## Function Attributes
+
+### Private Functions
+```rust
+#[external("private")]
+fn transfer(to: AztecAddress, amount: u128) {
+    // Client-side execution, generates proof
+}
+```
+
+### Public Functions
+```rust
+#[external("public")]
+fn mint(to: AztecAddress, amount: u128) {
+    // On-chain execution
+}
+```
+
+### Initializers
+```rust
+#[external("public")]
+#[initializer]
+fn constructor(admin: AztecAddress) {
+    self.storage.admin.write(admin);
+}
+```
+
+### View Functions
+```rust
+#[external("public")]
+#[view]
+fn get_balance(owner: AztecAddress) -> Field {
+    self.storage.balances.at(owner).read()
+}
+```
+
+### Internal Functions
+```rust
+#[external("public")]
+#[internal]
+fn _increase_balance(owner: AztecAddress, amount: u128) {
+    // Only callable by this contract
+}
+```
+
+### Unconstrained Functions
+```rust
+#[external("utility")]
+unconstrained fn balance_of_private(owner: AztecAddress) -> u128 {
+    self.storage.balances.at(owner).balance_of()
+}
+```
+
+## Storage Patterns
+
+### Private State (requires Owned wrapper)
+```rust
+#[storage]
+struct Storage<Context> {
+    // Private state MUST be wrapped in Owned
+    balances: Owned<PrivateSet<ValueNote, Context>, Context>,
+    user_data: Owned<PrivateMutable<DataNote, Context>, Context>,
+    secrets: Owned<PrivateImmutable<SecretNote, Context>, Context>,
+
+    // Public state - no wrapper needed
+    admin: PublicMutable<AztecAddress, Context>,
+    total_supply: PublicMutable<u128, Context>,
+}
+```
+
+### Map with Owned
+```rust
+// Per-user private balances
+balances: Map<AztecAddress, Owned<PrivateSet<ValueNote, Context>, Context>, Context>,
+```
+
+## Note Delivery
+
+Private state changes require explicit MessageDelivery:
+
+```rust
+// Constrained - encryption verified in circuit (more secure)
+self.storage.balances.at(owner).add(amount).deliver(MessageDelivery::CONSTRAINED_ONCHAIN);
+
+// Unconstrained - encryption not verified (cheaper)
+self.storage.balances.at(owner).add(amount).deliver(MessageDelivery::UNCONSTRAINED_ONCHAIN);
+```
+
+## Cross-Contract Calls
+
+### Call from Private
+```rust
+#[external("private")]
+fn call_other_contract(target: AztecAddress) {
+    // Synchronous call to another private function
+    OtherContract::at(target).private_function(args).call(&mut self.context);
+}
+```
+
+### Enqueue Public from Private
+```rust
+#[external("private")]
+fn shield_tokens(amount: u64) {
+    let sender = self.msg_sender().unwrap();
+    // Enqueue public call to execute after private portion
+    self.enqueue_self._deduct_public_balance(sender, amount);
+    // Continue with private logic
+    self.storage.balances.at(sender).add(amount as u128).deliver(MessageDelivery::CONSTRAINED_ONCHAIN);
+}
+```
+
+## Common Imports
+
+```rust
+use dep::aztec::{
+    macros::{
+        aztec,
+        functions::{external, initializer, internal, view, noinitcheck},
+        storage::storage,
+        events::event,
+    },
+    protocol_types::{address::AztecAddress, traits::ToField},
+    state_vars::{PublicMutable, PublicImmutable, PrivateSet, PrivateImmutable, PrivateMutable, Map, Owned},
+    messages::message_delivery::MessageDelivery,
+    note::note_getter_options::NoteGetterOptions,
+};
+```
+
+## Dependencies (Nargo.toml)
+
+```toml
+[package]
+name = "my_contract"
+type = "contract"
+
+[dependencies]
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.87.4-devnet.0", directory = "noir-projects/aztec-nr/aztec" }
+value_note = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.87.4-devnet.0", directory = "noir-projects/aztec-nr/value-note" }
+```
+
+Replace the tag with your target devnet version. All aztec-packages dependencies should use the same tag.

--- a/versions/mainnet/syntax.md
+++ b/versions/mainnet/syntax.md
@@ -1,0 +1,54 @@
+# Mainnet Syntax Reference
+
+This document will contain the canonical syntax for Aztec mainnet (stable production version).
+
+## Status
+
+**Mainnet is not yet available.** This file is a placeholder for future stable syntax.
+
+When mainnet launches, syntax may differ from devnet/testnet. Potential differences include:
+
+## Expected Differences (Tentative)
+
+These are potential syntax changes that may occur for mainnet stability. Verify against official docs when mainnet launches.
+
+### Function Attributes
+
+May revert to or add alternative syntax:
+```rust
+// Possible mainnet syntax (unconfirmed)
+#[aztec(private)]
+fn transfer(...) { }
+
+// Or may remain the same as devnet
+#[external("private")]
+fn transfer(...) { }
+```
+
+### Storage Patterns
+
+May simplify or modify `Owned<>` wrapper requirements.
+
+### Note Delivery
+
+May change `MessageDelivery` options or defaults.
+
+## Dependencies (Nargo.toml)
+
+```toml
+[package]
+name = "my_contract"
+type = "contract"
+
+[dependencies]
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v1.0.0", directory = "noir-projects/aztec-nr/aztec" }
+value_note = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v1.0.0", directory = "noir-projects/aztec-nr/value-note" }
+```
+
+## Migration Guide
+
+When mainnet syntax is finalized, a migration guide will be provided here to help upgrade contracts from devnet/testnet.
+
+## Current Recommendation
+
+Until mainnet launches, use **devnet** syntax for new development and **testnet** for integration testing.

--- a/versions/testnet/syntax.md
+++ b/versions/testnet/syntax.md
@@ -1,0 +1,48 @@
+# Testnet Syntax Reference
+
+This document contains the canonical syntax for Aztec testnet (pre-release testing version).
+
+## Status
+
+Testnet syntax is currently aligned with devnet. As testnet stabilizes, any differences will be documented here.
+
+## Function Attributes
+
+Same as devnet:
+- `#[external("private")]` for private functions
+- `#[external("public")]` for public functions
+- `#[external("utility")]` with `unconstrained` for view functions
+- `#[initializer]` for constructors
+- `#[internal]` for contract-internal functions
+- `#[view]` for read-only functions
+
+## Storage Patterns
+
+Same as devnet:
+- Private state requires `Owned<>` wrapper
+- `Owned<PrivateSet<T, Context>, Context>` for collections
+- `Owned<PrivateMutable<T, Context>, Context>` for single notes
+
+## Note Delivery
+
+Same as devnet:
+- `MessageDelivery::CONSTRAINED_ONCHAIN`
+- `MessageDelivery::UNCONSTRAINED_ONCHAIN`
+
+## Dependencies (Nargo.toml)
+
+```toml
+[package]
+name = "my_contract"
+type = "contract"
+
+[dependencies]
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.85.0", directory = "noir-projects/aztec-nr/aztec" }
+value_note = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.85.0", directory = "noir-projects/aztec-nr/value-note" }
+```
+
+Replace the tag with your target testnet version.
+
+## Differences from Devnet
+
+Currently none documented. Check release notes for your specific testnet version.

--- a/versions/versions.json
+++ b/versions/versions.json
@@ -1,0 +1,38 @@
+{
+  "default": "devnet",
+  "versions": {
+    "devnet": {
+      "name": "devnet",
+      "description": "Latest development version (default)",
+      "tagPatterns": [
+        "aztec-packages-v[0-9.]+-devnet",
+        "aztec-packages-v0\\.(8[7-9]|9[0-9])\\."
+      ],
+      "exampleTag": "aztec-packages-v0.87.4-devnet.0",
+      "notes": "Current active development. May have breaking changes."
+    },
+    "testnet": {
+      "name": "testnet",
+      "description": "Pre-release testing version",
+      "tagPatterns": [
+        "aztec-packages-v0\\.(8[0-6])\\."
+      ],
+      "exampleTag": "aztec-packages-v0.85.0",
+      "notes": "Release candidates for testnet deployment."
+    },
+    "mainnet": {
+      "name": "mainnet",
+      "description": "Stable production release (future)",
+      "tagPatterns": [
+        "aztec-packages-v1\\."
+      ],
+      "exampleTag": "aztec-packages-v1.0.0",
+      "notes": "Stable syntax for production. Not yet available."
+    }
+  },
+  "detection": {
+    "files": ["Nargo.toml", "contracts/*/Nargo.toml", "*/Nargo.toml"],
+    "searchPattern": "aztec.*tag.*=.*\"(aztec-packages-v[^\"]+)\"",
+    "fallback": "devnet"
+  }
+}


### PR DESCRIPTION
## Summary

- Refactors versioning to work with marketplace installs by embedding all version-specific content in a single plugin
- Adds auto-detection of Aztec version from user's Nargo.toml
- Defaults to devnet syntax (current documented patterns)
- No longer requires git branches to switch versions

## Changes

### New Files
- `versions/versions.json` - Version definitions and tag patterns
- `versions/devnet/syntax.md` - Complete devnet syntax reference
- `versions/testnet/syntax.md` - Testnet syntax reference  
- `versions/mainnet/syntax.md` - Mainnet placeholder (future)
- `commands/detect-version.md` - Slash command to detect project version

### Modified Files
- `setup.sh` - Replaced git-branch switching with config-based approach
- `CLAUDE.md` - Added version detection instructions
- `plugin.json` - Bumped to v2.0.0, added version config
- `README.md` - Updated versioning documentation
- `NETWORK.md` - Complete rewrite for new approach
- `.gitignore` - Changed `network.json` to `.aztec-version`

## How It Works

1. **Auto-detection**: Plugin parses `Nargo.toml` for `aztec-packages-v*` tags
2. **Pattern matching**: Maps tags to devnet/testnet/mainnet
3. **Config file**: Stores version choice in `.aztec-version`
4. **Default**: Uses devnet if no version detected

## Test plan

- [ ] Install plugin fresh, verify devnet syntax used by default
- [ ] Create project with Nargo.toml containing devnet tag, verify detection
- [ ] Run `./setup.sh testnet`, verify version changes
- [ ] Run `/aztec:detect-version`, verify output
- [ ] Delete `.git` folder from plugin, verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)