### PR TITLE
docs: add fail-fast code philosophy to TypeScript skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "critesjosh/aztec-claude-plugin"
       },
       "description": "Claude Code plugin for Aztec smart contract and application development",
-      "version": "1.6.1"
+      "version": "1.6.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aztec",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Claude Code plugin for Aztec smart contract and application development. Provides specialized agents, skills, and commands for building privacy-preserving applications on Aztec Network.",
   "author": {
     "name": "critesjosh"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,39 @@
+name: Version Bump Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-version-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version was bumped
+        run: |
+          BASE_VERSION=$(git show origin/main:.claude-plugin/plugin.json | jq -r '.version')
+          PR_PLUGIN_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+          PR_MARKETPLACE_VERSION=$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)
+
+          echo "Base version (main):       $BASE_VERSION"
+          echo "PR plugin.json version:    $PR_PLUGIN_VERSION"
+          echo "PR marketplace.json version: $PR_MARKETPLACE_VERSION"
+
+          # Check plugin.json and marketplace.json are in sync
+          if [ "$PR_PLUGIN_VERSION" != "$PR_MARKETPLACE_VERSION" ]; then
+            echo "::error::Version mismatch! plugin.json ($PR_PLUGIN_VERSION) != marketplace.json ($PR_MARKETPLACE_VERSION)"
+            exit 1
+          fi
+
+          # Check version was actually bumped
+          if [ "$PR_PLUGIN_VERSION" = "$BASE_VERSION" ]; then
+            echo "::error::Version not bumped! Both main and this PR are at $BASE_VERSION. Please bump the version in .claude-plugin/plugin.json and .claude-plugin/marketplace.json."
+            exit 1
+          fi
+
+          echo "Version bumped: $BASE_VERSION -> $PR_PLUGIN_VERSION"

--- a/skills/aztec-accounts/SKILL.md
+++ b/skills/aztec-accounts/SKILL.md
@@ -8,6 +8,10 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash
 
 Create, deploy, and manage Aztec accounts with proper key management.
 
+## Code Philosophy
+
+You are writing application code, not library code. Application code should fail fast and loud. Do not add resilience patterns (retries, fallbacks, default values) unless explicitly requested. The developer's debugging experience is more important than the app "not crashing" — a crash with a clear error message is always better than silent misbehavior.
+
 ## Subskills
 
 * [Schnorr Accounts](./schnorr-accounts.md) - Creating and deploying Schnorr accounts

--- a/skills/aztec-deploy/SKILL.md
+++ b/skills/aztec-deploy/SKILL.md
@@ -8,6 +8,10 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash
 
 Generate production-ready TypeScript deployment scripts for Aztec smart contracts.
 
+## Code Philosophy
+
+You are writing application code, not library code. Application code should fail fast and loud. Do not add resilience patterns (retries, fallbacks, default values) unless explicitly requested. The developer's debugging experience is more important than the app "not crashing" — a crash with a clear error message is always better than silent misbehavior.
+
 ## Subskills
 
 Navigate to the appropriate section based on your task:

--- a/skills/aztec-e2e-testing/SKILL.md
+++ b/skills/aztec-e2e-testing/SKILL.md
@@ -8,6 +8,10 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash
 
 Generate end-to-end tests for Aztec contracts against live networks. Vitest is the default test runner in v4; Jest is also supported.
 
+## Code Philosophy
+
+You are writing application code, not library code. Application code should fail fast and loud. Do not add resilience patterns (retries, fallbacks, default values) unless explicitly requested. The developer's debugging experience is more important than the app "not crashing" — a crash with a clear error message is always better than silent misbehavior.
+
 ## Subskills
 
 * [Integration Test Recipe](./integration-test-recipe.md) - Complete copy-paste-ready test with multi-account, authwit, cross-contract patterns

--- a/skills/aztec-typescript/SKILL.md
+++ b/skills/aztec-typescript/SKILL.md
@@ -8,6 +8,10 @@ allowed-tools: Read, Grep, Glob, Edit, Write, Bash
 
 Generate TypeScript code for interacting with Aztec contracts.
 
+## Code Philosophy
+
+You are writing application code, not library code. Application code should fail fast and loud. Do not add resilience patterns (retries, fallbacks, default values) unless explicitly requested. The developer's debugging experience is more important than the app "not crashing" — a crash with a clear error message is always better than silent misbehavior.
+
 ## Subskills
 
 * [Contract Client](./contract-client.md) - Type-safe contract interaction wrapper


### PR DESCRIPTION
## Summary

- Adds a "Code Philosophy" section to the four TypeScript-generating skills: `aztec-typescript`, `aztec-deploy`, `aztec-e2e-testing`, and `aztec-accounts`
- Instructs Claude to write application code that fails fast and loud — no retries, fallbacks, or silent defaults unless explicitly requested
- Skips Noir/contract skills where `assert()` already enforces fail-fast by design

## Test plan

- [ ] Verify each modified SKILL.md renders correctly
- [ ] Test that code generation from these skills avoids unnecessary try/catch and fallback patterns